### PR TITLE
accessor get path method can be with or without error

### DIFF
--- a/sqlalchemy_api_handler/bases/accessor.py
+++ b/sqlalchemy_api_handler/bases/accessor.py
@@ -1,9 +1,13 @@
 import inflect
 
+from sqlalchemy_api_handler.bases.errors import GetPathError
+
 
 class Accessor():
 
-    def get(self, path):
+    def get(self,
+            path,
+            with_get_path_error=True):
         if '.' in path:
             chunks = path.split('.')
             key = chunks[0]
@@ -16,7 +20,14 @@ class Accessor():
                     next_path = '.'.join(chunks[2:])
             else:
                 next_path = '.'.join(chunks[1:])
-            return value.get(next_path)
+            if value:
+                return value.get(next_path, with_get_path_error=with_get_path_error)
+            if with_get_path_error:
+                errors = GetPathError()
+                errors.add_error('path', f'This path {path} returns a None with entity {str(self)} at key {key}')
+                raise errors
+            return None
+
         return getattr(self, path)
 
     @classmethod

--- a/sqlalchemy_api_handler/bases/accessor.py
+++ b/sqlalchemy_api_handler/bases/accessor.py
@@ -8,27 +8,36 @@ class Accessor():
     def get(self,
             path,
             with_get_path_error=True):
-        if '.' in path:
-            chunks = path.split('.')
-            key = chunks[0]
-            value = getattr(self, key)
-            if chunks[1].isdigit():
-                value = value[int(chunks[1])]
-                if len(chunks) == 2:
-                    return value
-                else:
-                    next_path = '.'.join(chunks[2:])
-            else:
-                next_path = '.'.join(chunks[1:])
-            if value:
-                return value.get(next_path, with_get_path_error=with_get_path_error)
-            if with_get_path_error:
-                errors = GetPathError()
-                errors.add_error('path', f'This path {path} returns a None with entity {str(self)} at key {key}')
-                raise errors
-            return None
 
-        return getattr(self, path)
+        is_direct_attribute_key =  '.' not in path
+        if is_direct_attribute_key:
+            return getattr(self, path)
+
+        chunks = path.split('.')
+        key = chunks[0]
+        value = getattr(self, key)
+
+        child_key = chunks[1]
+        start_index_for_child_path = 1
+        child_key_is_index = child_key.isdigit()
+        if child_key_is_index:
+            value = value[int(child_key)]
+            path_is_direct_a_get_of_child_element = len(chunks) == 2
+            if path_is_direct_a_get_of_child_element:
+                return value
+            start_index_for_child_path = 2
+
+        child_path = '.'.join(chunks[start_index_for_child_path:])
+
+        if value is not None:
+            return value.get(child_path, with_get_path_error=with_get_path_error)
+
+        if with_get_path_error:
+            errors = GetPathError()
+            errors.add_error('path', f'This path {path} returns a None with entity {str(self)} at key {key}')
+            raise errors
+
+        return None
 
     @classmethod
     def get_db(cls):

--- a/sqlalchemy_api_handler/bases/errors.py
+++ b/sqlalchemy_api_handler/bases/errors.py
@@ -122,6 +122,10 @@ class ForbiddenError(ApiErrors):
     pass
 
 
+class GetPathError(ApiErrors):
+    pass
+
+
 class NotSoftDeletableMixinException(ApiErrors):
     pass
 

--- a/tests/bases/accessor_test.py
+++ b/tests/bases/accessor_test.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy_api_handler.bases.errors import GetPathError
 
 from api.models.offer import Offer
 from api.models.stock import Stock
@@ -27,3 +28,21 @@ class AccessorTest:
 
         # Then
         assert stock_price == stock.price
+
+    def test_get_with_a_failing_empty_path(self, app):
+        # Given
+        stock = Stock(price=1)
+
+        # When
+        with pytest.raises(GetPathError):
+            offer_name = stock.get('offer.name')
+
+    def test_get_with_a_silent_empty_path_return(self, app):
+        # Given
+        stock = Stock(price=1)
+
+        # When
+        offer_name = stock.get('offer.name', with_get_path_error=False)
+
+        # Then
+        assert offer_name == None


### PR DESCRIPTION
I need to make, as optional, the `entity.get('foo.bar.fee')` not throw an error if an intermediate value does not exist.

It helps in the context of this PR : https://gitlab.com/mayane/mayane-main/-/merge_requests/161. This PR retrieves information for towns, given their canton, district. The ETL script calls a `town.get('canton.district.dis')` and some towns actually have not an attached canton, so it is normal to that the get method returns None in that case.

Thanks