### PR TITLE
not found when wrong human id

### DIFF
--- a/api/.pylintrc
+++ b/api/.pylintrc
@@ -139,6 +139,7 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
+        missing-class-docstring,
         missing-module-docstring,
         missing-function-docstring
 

--- a/sqlalchemy_api_handler/utils/dehumanize.py
+++ b/sqlalchemy_api_handler/utils/dehumanize.py
@@ -1,5 +1,5 @@
 import binascii
-from base64 import b32encode, b32decode
+from base64 import b32decode
 from typing import Any
 
 from sqlalchemy_api_handler.utils.is_id_column import is_id_column

--- a/sqlalchemy_api_handler/utils/load_or_404.py
+++ b/sqlalchemy_api_handler/utils/load_or_404.py
@@ -1,6 +1,19 @@
+# pylint: disable=C0301
+
 from sqlalchemy_api_handler.utils.dehumanize import dehumanize
+from sqlalchemy_api_handler.utils.humanize import humanize
+from werkzeug.exceptions import NotFound
+
+
+class WrongHumanizeId(Exception):
+    pass
 
 
 def load_or_404(obj_class, human_id):
-    return obj_class.query.filter_by(id=dehumanize(human_id))\
+    dehumanized_id = dehumanize(human_id)
+    base_human_id = humanize(dehumanized_id)
+    if base_human_id != human_id:
+        raise NotFound('this humanized id {} is not the correct base value for the matching dehumanized id {}, it should be {}'.format(human_id, dehumanized_id, base_human_id))
+
+    return obj_class.query.filter_by(id=dehumanized_id)\
                           .first_or_404()

--- a/tests/utils/load_or_404_test.py
+++ b/tests/utils/load_or_404_test.py
@@ -1,0 +1,43 @@
+import pytest
+from werkzeug.exceptions import NotFound
+from sqlalchemy_api_handler import ApiHandler
+from sqlalchemy_api_handler.utils.humanize import humanize
+from sqlalchemy_api_handler.utils.load_or_404 import load_or_404
+
+from tests.conftest import with_delete
+from api.models.offer import Offer
+
+
+class LoadOr404Test:
+    @with_delete
+    def test_load_entity(self, app):
+        # Given
+        offer1 = Offer(name='foo', type='bar')
+        ApiHandler.save(offer1)
+
+        # When
+        offer2 = load_or_404(Offer, humanize(offer1.id))
+
+        # Then
+        assert offer1.id == offer2.id
+
+    @with_delete
+    def test_404_with_not_existing_id(self, app):
+        # Given
+        offer1 = Offer(name='foo', type='bar')
+        ApiHandler.save(offer1)
+
+        # When
+        with pytest.raises(NotFound):
+            load_or_404(Offer, humanize(offer1.id + 1))
+
+    @with_delete
+    def test_404_with_wrong_base_id(self, app):
+        # Given
+        offer1 = Offer(name='foo', type='bar')
+        offer1.id = 6
+        ApiHandler.save(offer1)
+
+        # When
+        with pytest.raises(NotFound):
+            load_or_404(Offer, 'AZ')


### PR DESCRIPTION
C'est pour eviter un cas d'usage qui est RARE mais quand ça arrive, ça fout la tete à l'envers et ça nous est arrivé aujourd'hui avec science feedback.

On a un url front genre `localhost:3000/offers/AY` => retourne moi la donnée de l'entité offer avec offer.id = 6 et humanize(6) = AY.
Jusque là ok.

Mais un de nous a sans faitre expres tappé :
`localhost:3000/offers/AZ` et en fait ça retourne quand meme de la part de l'api l'entité (mais apres côté front ça bug). Pourquoi ? Car dehumanize(AZ) = dehumanize(AY) = 6.

Donc c'est un peu misleading, à un certains point, j'avais oublié que la fonction dehumanize est surjective.

Le mieux je trouve est donc de forcer de considerer comme not found tous les human ids possibles qui ne sont pas celui qu'on obtient de base avec la fonction inverse, humanize(6) => AY (ie le premier en fait de la série)

Merci de votre attention.



