### PR TITLE
handle InvalidRequestError when saving

### DIFF
--- a/sqlalchemy_api_handler/bases/save.py
+++ b/sqlalchemy_api_handler/bases/save.py
@@ -1,4 +1,4 @@
-from sqlalchemy.exc import DataError, IntegrityError, InternalError
+from sqlalchemy.exc import DataError, IntegrityError, InternalError, InvalidRequestError
 
 from sqlalchemy_api_handler.bases.errors import Errors
 from sqlalchemy_api_handler.bases.modify import Modify
@@ -30,6 +30,10 @@ class Save(Modify, Errors):
         except InternalError as ie:
             for entity in entities:
                 api_errors.add_error(*entity.restize_internal_error(ie))
+            db.session.rollback()
+            raise api_errors
+        except InvalidRequestError as ire:
+            api_errors.add_error(*Errors.restize_internal_error(ire))
             db.session.rollback()
             raise api_errors
         except TypeError as te:


### PR DESCRIPTION
For cases like this
```bash
Task tasks.providers.modify_providers_with_reset_calls_count[e8fddb0f-5b58-454c-9a0e-cfca0f856fd7] raised unexpected: 
InvalidRequestError('This Session\'s transaction has been rolled back due to a previous exception during flush. To begin a new 
transaction with this Session, first issue Session.rollback(). Original exception was: (raised as a result of Query-invoked autoflush;
 consider using a session.no_autoflush block if this flush is occurring prematurely)\n(psycopg2.errors.StringDataRightTruncation) 
value too long for type character varying(64)